### PR TITLE
Setup Initial Admin Routes

### DIFF
--- a/UX/backend/src/app.module.ts
+++ b/UX/backend/src/app.module.ts
@@ -5,10 +5,12 @@ import { PageController } from './controllers/pages.controller';
 import { PageService } from './services/pages.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { SupabaseService } from './services/supabase.service';
+import { AdminController } from './controllers/admin.controller';
+import { AdminService } from './services/admin.service';
 
 @Module({
   imports: [ConfigModule.forRoot()],
-  controllers: [AppController, PageController],
-  providers: [AppService, PageService, ConfigService, SupabaseService],
+  controllers: [AppController, PageController, AdminController],
+  providers: [AppService, PageService, ConfigService, SupabaseService, AdminService],
 })
 export class AppModule {}

--- a/UX/backend/src/controllers/admin.controller.ts
+++ b/UX/backend/src/controllers/admin.controller.ts
@@ -1,0 +1,14 @@
+import { Body, Controller, Param, Patch, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { AdminService } from 'src/services/admin.service';
+import { ApiResponse, Page } from 'src/types/types';
+
+@Controller('admin')
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+ 
+  @Patch(':page') 
+  updatePage(@Param('page') page: string, @Body() updatedPage: Page) {
+    return this.adminService.updatePage(page, updatedPage)
+  }
+}

--- a/UX/backend/src/controllers/pages.controller.ts
+++ b/UX/backend/src/controllers/pages.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { PageService } from 'src/services/pages.service';
 
 // These are the routes for the pages
@@ -6,13 +6,18 @@ import { PageService } from 'src/services/pages.service';
 export class PageController {
   constructor(private readonly pageService: PageService) {}
 
- @Get() 
-  getPages() {
-    return this.pageService.getPages()
-  }
-
   @Get('reviews')
   getReviews() {
     return this.pageService.getReviews()
   }
+  
+  @Get(':page') 
+  getPage(@Param('page') page: string) {
+    return this.pageService.getPage(page)
+  }
+  
+  @Get() 
+   getPages() {
+     return this.pageService.getPages()
+   }
 }

--- a/UX/backend/src/main.ts
+++ b/UX/backend/src/main.ts
@@ -3,7 +3,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.enableCors()
+  app.enableCors({origin: ['http://localhost:5173']})
   await app.listen(process.env.PORT ?? 5000);
 }
 bootstrap();

--- a/UX/backend/src/services/admin.service.ts
+++ b/UX/backend/src/services/admin.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { SupabaseService } from './supabase.service';
+import { ApiResponse, Page } from 'src/types/types';
+
+/*
+// This service is for admins to use,
+// Update content, reviews etc.
+*/
+@Injectable()
+export class AdminService {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+
+  async updatePage(
+    page: string,
+    updatedPage: Page,
+  ): Promise<ApiResponse<string>> {
+    try {
+      const CLIENT = this.supabaseService.supabase
+      const {data, error} = await CLIENT.storage
+      .from('pages')
+      .upload(`${page}.json`, JSON.stringify(updatedPage), {
+        upsert: true
+      })
+      
+      if (error) {
+        console.error(error)
+        throw new Error('Error when updating data: ', error);
+      }
+
+      return {
+        message: 'File was successfully uploaded!',
+        data: data.path,
+        error: null
+      };
+
+    } catch (error) {
+      throw new Error(`Error when updating page: `, error);
+    }
+  }
+}

--- a/UX/backend/src/types/types.ts
+++ b/UX/backend/src/types/types.ts
@@ -1,41 +1,115 @@
+// General structure of backend API response
 export interface ApiResponse<T> {
-  data: T,
-  error: null | string
+  data: T;
+  error: null | string;
+  message?: string;
 }
 
-export type ReviewWithClient = {
+export interface Review {
   content: string;
-  clients: {
-    company_name: string;
-  }[]; // now accepts array of clients
-};
-
-
-export interface FormattedReview {
-  content: string
-  client: string
+  client: string;
 }
 
-export interface Page {
-  pageTitle: string,
-  sections: {
-    sectionHeader: Section[]
-  }
+// Pages is the type definition for an object containing all pages
+export interface Pages {
+  hero: HeroPage,
+  product: ProductPage,
+  support: SupportPage
+}
+// Page is the type definition of one of the pages
+export type Page = HeroPage | ProductPage | SupportPage
+
+// Type for Hero Page data
+export interface HeroPage {
+  banner: {
+    heading: {
+      label: 'Page Title';
+      type: 'input:text';
+      value: string;
+      minLength: 15,
+      maxLength: 100
+    };
+    subheading: {
+      label: 'Subheading';
+      type: 'input:textarea';
+      value: string;
+      minLength: 15,
+      maxLength: 500
+    };
+    banner: {
+      // Media referrs to image or video format
+      type: 'upload:media',
+      filePath: string
+    }
+  };
 }
 
-export interface Section {
-  editableFields: EditableField[]
+// Type for Product Page data
+export interface ProductPage {
+  features: {
+    type: 'input:text';
+    value: string;
+    minLength: number;
+    maxLength: number;
+  }[];
+  statistics: {
+    sun: {
+      label: 'Statistic 1';
+      value: string;
+      type: 'input:text';
+    };
+    planet1: {
+      label: 'Statistic 2';
+      value: string;
+      type: 'input:text';
+    };
+    planet2: {
+      label: 'Statistic 3';
+      value: string;
+      type: 'input:text';
+    };
+    planet3: {
+      label: 'Statistic 4';
+      value: string;
+      type: 'input:text';
+    };
+    planet4: {
+      label: 'Statistic 5';
+      value: string;
+      type: 'input:text';
+    };
+  };
+  gallery: {
+    type: 'img' | 'video',
+    width: number,
+    height: number,
+    filePath: string
+  }[];
+  manual: {
+    label: '"TERRA-X9 Instruction Manual"';
+    filepath: string;
+  };
 }
 
-export interface EditableField {
-  [key: string]: {
-    label: string,
-    type: string,
-    filePath?: string
-  }
-}
-
-export interface FormattedPageData {
-  name: string,
-  content: object
+// Type for Support Page Data
+export interface SupportPage {
+  manuals: {
+    instructionManual: {
+      label: 'Instruction Manual';
+      filePath: string;
+      input: 'upload:document'
+    },
+    GPSR: {
+      label: 'General Product Safety Regulation';
+      filePath: string;
+      input: 'upload:document'
+    }
+  },
+  FAQ: {
+    categoryName: string;
+    data: {
+      question: string;
+      answer: string;
+    }[];
+  }[],
 }

--- a/UX/frontend/src/api/contentApi.ts
+++ b/UX/frontend/src/api/contentApi.ts
@@ -1,8 +1,9 @@
 import { api } from './axios';
-import { PageData, FormattedReview, ApiResponse } from '../types/types';
+import { Page, Review, ApiResponse, Pages } from '@/types/types';
 
 // Api gets content from the backend
 export const contentApi = {
-  getPages: (): Promise<ApiResponse<PageData[]>> => api.get('pages'),
-  getReviews: (): Promise<ApiResponse<FormattedReview[]>> => api.get('pages/reviews')
+  getPages: (): Promise<ApiResponse<Pages>> => api.get('pages'),
+  getPage: (page: string): Promise<ApiResponse<Page>> => api.get(`pages/${page}`),
+  getReviews: (): Promise<ApiResponse<Review[]>> => api.get('pages/reviews')
 }

--- a/UX/frontend/src/context/ContentContext.tsx
+++ b/UX/frontend/src/context/ContentContext.tsx
@@ -1,9 +1,9 @@
 import { createContext } from 'react';
-import { FormattedPageData, FormattedReview } from '../types/types';
+import { Review, Pages } from '@/types/types';
 
 export interface ContentContextType {
-  pages: FormattedPageData | null,
-  reviews: FormattedReview[] | null
+  pages: Pages | null,
+  reviews: Review[] | null
 }
 
 export const ContentContext = createContext<ContentContextType | undefined>(undefined);

--- a/UX/frontend/src/context/ContentProvider.tsx
+++ b/UX/frontend/src/context/ContentProvider.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, ReactNode } from 'react';
 import { ContentContext, ContentContextType } from './ContentContext';
 import { contentApi } from '../api/contentApi';
-import { FormattedPageData } from '../types/types';
 
 export function ContentProvider({ children }: { children: ReactNode }) {
   const [pages, setPages] = useState<ContentContextType['pages']>(null);
@@ -10,15 +9,8 @@ export function ContentProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     contentApi.getPages()
-      .then((result) => {
-        const formattedData: FormattedPageData = result.data.reduce((acc, page) => {
-          acc[page.name] = {
-            content: page.content
-          };
-          return acc;
-        }, {} as FormattedPageData);
-        setPages(formattedData)
-      });
+      .then((result) => setPages(result.data))
+      .finally(() => setLoading(false))
 
     contentApi.getReviews()
       .then(result => setReviews(result.data))

--- a/UX/frontend/src/pages/Hero.tsx
+++ b/UX/frontend/src/pages/Hero.tsx
@@ -35,7 +35,7 @@ function Hero() {
             height: '100%',
             textAlign: 'end'
           }}>
-          <Typography variant='h1' color='text.light'>{pages?.hero?.content?.h1}</Typography>
+          <Typography variant='h1' color='text.light'>{pages?.hero.banner.heading.value}</Typography>
           <Typography variant='body1' color='text.light'
             sx={{
               mt: 2,

--- a/UX/frontend/src/types/types.ts
+++ b/UX/frontend/src/types/types.ts
@@ -1,58 +1,115 @@
+// General structure of backend API response
 export interface ApiResponse<T> {
-  data: T,
-  error: null | string
+  data: T;
+  error: null | string;
+  message?: string;
 }
 
-export interface PageData {
-  name: string,
-  content: PageContent,
-  id: string
+export interface Review {
+  content: string;
+  client: string;
 }
 
-export type FormattedPageData = {
-  [key: string]: {
-    content: PageContent
+// Pages is the type definition for an object containing all pages
+export interface Pages {
+  hero: HeroPage,
+  product: ProductPage,
+  support: SupportPage
+}
+// Page is the type definition of one of the pages
+export type Page = HeroPage | ProductPage | SupportPage
+
+// Type for Hero Page data
+export interface HeroPage {
+  banner: {
+    heading: {
+      label: 'Page Title';
+      type: 'input:text';
+      value: string;
+      minLength: 15,
+      maxLength: 100
+    };
+    subheading: {
+      label: 'Subheading';
+      type: 'input:textarea';
+      value: string;
+      minLength: 15,
+      maxLength: 500
+    };
+    banner: {
+      // Media referrs to image or video format
+      type: 'upload:media',
+      filePath: string
+    }
   };
-};
-
-export interface PageContent {
-  h1?: string
-  h2?: string
-  h3?: string
-  h4?: string
-  h5?: string
-  h6?: string
-  p?: string
 }
 
-export interface OriginalReview {
-  content: any;
-  clients: {
-    company_name: any;
+// Type for Product Page data
+export interface ProductPage {
+  features: {
+    type: 'input:text';
+    value: string;
+    minLength: number;
+    maxLength: number;
+  }[];
+  statistics: {
+    sun: {
+      label: 'Statistic 1';
+      value: string;
+      type: 'input:text';
+    };
+    planet1: {
+      label: 'Statistic 2';
+      value: string;
+      type: 'input:text';
+    };
+    planet2: {
+      label: 'Statistic 3';
+      value: string;
+      type: 'input:text';
+    };
+    planet3: {
+      label: 'Statistic 4';
+      value: string;
+      type: 'input:text';
+    };
+    planet4: {
+      label: 'Statistic 5';
+      value: string;
+      type: 'input:text';
+    };
   };
-};
-
-export interface FormattedReview {
-  content: string
-  client: string
+  gallery: {
+    type: 'img' | 'video',
+    width: number,
+    height: number,
+    filePath: string
+  }[];
+  manual: {
+    label: '"TERRA-X9 Instruction Manual"';
+    filepath: string;
+  };
 }
 
-
-export interface Page {
-  pageTitle: string,
-  sections: {
-    sectionHeader: Section[]
-  }
-}
-
-export interface Section {
-  editableFields: EditableField[]
-}
-
-export interface EditableField {
-  [key: string]: {
-    label: string,
-    type: string,
-    filePath?: string
-  }
+// Type for Support Page Data
+export interface SupportPage {
+  manuals: {
+    instructionManual: {
+      label: 'Instruction Manual';
+      filePath: string;
+      input: 'upload:document'
+    },
+    GPSR: {
+      label: 'General Product Safety Regulation';
+      filePath: string;
+      input: 'upload:document'
+    }
+  },
+  FAQ: {
+    categoryName: string;
+    data: {
+      question: string;
+      answer: string;
+    }[];
+  }[],
 }


### PR DESCRIPTION
### Summary
Added backend routes for admins of the product website to update page content (No UI for this yet)
Also now fetches page data from the database

### How to test it:
If it works as it should, when starting up both servers you should be able to see "Seamless Pickup, Beyond Planets" when visiting the home page '/'

