### PR TITLE
178/streaming reconnection bug

### DIFF
--- a/Backend/Server-test-connection-for-Rover/exampleClient.py
+++ b/Backend/Server-test-connection-for-Rover/exampleClient.py
@@ -5,7 +5,7 @@ import json
 import base64
 from datetime import datetime
 
-URI = "ws://13.60.235.253:9000"
+URI = "ws://localhost:9000"
 
 # Used to get messages from terminal
 
@@ -35,7 +35,7 @@ async def receive_messages(websocket):
 
                     print(f"\nImage saved as {filename}")
                 else:
-                    print(f"\nReceived (non-image): {"sdf"}")
+                    print(f"\nReceived (non-image): {message}")
             except json.JSONDecodeError:
                 print(f"\nReceived (non-JSON): {message}")
 

--- a/Backend/Server/app.js
+++ b/Backend/Server/app.js
@@ -13,4 +13,4 @@ initializeWebSocketServer(server);
 startStreamingServer({
     inputPort: 1234,
     outputPort: 9000
-}); 
+});

--- a/Backend/Server/streamingServer.js
+++ b/Backend/Server/streamingServer.js
@@ -5,6 +5,7 @@ import { WebSocketServer } from 'ws';
 function startStreamingServer(ports) {
     const wss = new WebSocketServer({ port: ports.outputPort });
     const clients = new Set();
+    //let streamProcess = null
 
     // Output
     wss.on('connection', (ws) => {
@@ -17,31 +18,41 @@ function startStreamingServer(ports) {
         });
     });
 
-    // Input
-    const stream = spawn('ffmpeg', [
-        '-fflags', 'nobuffer', // reduce buffering for lower latency
-        '-i', `srt://0.0.0.0:${ports.inputPort}?mode=listener`, // listen for incoming SRT connections on the given port
-        '-c:v', 'copy', // copy the video stream without re-encoding
-        '-an', // disable audio processing
-        '-f', 'mpegts', // output format is MPEG-TS
-        'pipe:1' // send the output to stdout
-    ])
 
-    stream.stdout.on('data', (chunk) => {
-        for (const client of clients) {
-            if (client.readyState === WebSocket.OPEN) {
-                client.send(chunk);
+    // Start FFMPEG process, listening for the stream from rover
+    startFFMPEG();
+
+    function startFFMPEG(){
+        // Input
+        const streamProcess = spawn('ffmpeg', [
+            '-fflags', 'nobuffer', // reduce buffering for lower latency
+            '-i', `srt://0.0.0.0:${ports.inputPort}?mode=listener`, // listen for incoming SRT connections on the given port
+            '-c:v', 'copy', // copy the video stream without re-encoding
+            '-an', // disable audio processing
+            '-f', 'mpegts', // output format is MPEG-TS
+            'pipe:1' // send the output to stdout
+        ])
+
+        streamProcess.stdout.on('data', (chunk) => {
+            for (const client of clients) {
+                if (client.readyState === WebSocket.OPEN) {
+                    client.send(chunk);
+                }
             }
-        }
-    })
+        })
 
-    stream.stderr.on('data', (data) => {
-        console.error(`[ffmpeg] ${data}`);
-    });
+        streamProcess.stderr.on('data', (data) => {
+            console.error(`[ffmpeg] ${data}`);
+        });
 
-    stream.on('close', (code) => {
-        console.log(`FFmpeg exited with code ${code}`);
-    });
+        streamProcess.on('close', (code) => {
+            console.log(`FFmpeg exited with code ${code}`);
+            // Start new ffmpeg process after previous one is closed
+            setTimeout(startFFMPEG, 1000);
+        });
+    }
+
+
 }
 
 export default startStreamingServer

--- a/Backend/Server/streamingServer.js
+++ b/Backend/Server/streamingServer.js
@@ -5,7 +5,6 @@ import { WebSocketServer } from 'ws';
 function startStreamingServer(ports) {
     const wss = new WebSocketServer({ port: ports.outputPort });
     const clients = new Set();
-    //let streamProcess = null
 
     // Output
     wss.on('connection', (ws) => {
@@ -18,11 +17,10 @@ function startStreamingServer(ports) {
         });
     });
 
-
     // Start FFMPEG process, listening for the stream from rover
     startFFMPEG();
 
-    function startFFMPEG(){
+    function startFFMPEG() {
         // Input
         const streamProcess = spawn('ffmpeg', [
             '-fflags', 'nobuffer', // reduce buffering for lower latency
@@ -51,8 +49,6 @@ function startStreamingServer(ports) {
             setTimeout(startFFMPEG, 1000);
         });
     }
-
-
 }
 
 export default startStreamingServer


### PR DESCRIPTION
### Fixed bug: streaming didn’t work after sending "stop stream" to the rover

**Why it happened**
There was a bug in the streaming server app — after the connection on port 1234 was closed, the process listening to that port stopped and didn’t restart. So when trying to stream again, nothing happened.

**What I did**
I moved the ffmpeg process into a function. Now, when the streaming connection is closed, the server automatically restarts the ffmpeg process and calls the function to listen for new streams again.