### PR TITLE
177/fix mutliple message logs

### DIFF
--- a/Backend/Server/websocketServer.js
+++ b/Backend/Server/websocketServer.js
@@ -62,7 +62,7 @@ function initializeWebSocketServer(server) {
             return parsed
         }
         catch (err) {
-            console.log("Message isn't valid JSON. Parsing as raw...")
+            console.warn("Message isn't valid JSON. Parsing as raw...")
             const parsed = { raw: message.toString() }
             return parsed
         }

--- a/Backend/Server/websocketServer.js
+++ b/Backend/Server/websocketServer.js
@@ -11,6 +11,8 @@ function initializeWebSocketServer(server) {
         clients.add(ws);
 
         ws.on('message', (msg) => {
+            // Log client and it's message
+            console.log(`[Message]: ${msg}`)
 
             // Special ping/pong case
             if (msg == "ping") {
@@ -46,7 +48,6 @@ function initializeWebSocketServer(server) {
     function forwardMessageToAllClients(parsed, clients, ws) {
         clients.forEach((client) => {
             if (client.readyState === WebSocket.OPEN) {
-                console.log(parsed)
                 client.send(JSON.stringify({
                     sender: client === ws ? '[SERVER]' : '[CLIENT]', ...parsed
                 }))

--- a/Backend/Server/websocketServer.js
+++ b/Backend/Server/websocketServer.js
@@ -62,7 +62,7 @@ function initializeWebSocketServer(server) {
             return parsed
         }
         catch (err) {
-            console.log("The message couldn't be parsed. ", err)
+            console.log("Message isn't valid JSON. Parsing as raw...")
             const parsed = { raw: message.toString() }
             return parsed
         }


### PR DESCRIPTION
# Simple fix

Moved a console log from `forwardMessageToAllClients` to the message event.

Bonus feature: fixed long errors in log