### PR TITLE
155 implement first mfa draft

### DIFF
--- a/UX/README.md
+++ b/UX/README.md
@@ -1,1 +1,17 @@
 # UX
+
+## Local Development
+
+**Starting the backend server**
+
+1. Navigate into the `/backend` directory using a terminal
+2. Run `npm install`
+3. After dependencies have finished installing, start up the server using `npm start`
+4. The server should be running at http://localhost:5000
+
+**Starting the frontend server**
+
+1. Navigate to the `/frontend` directory using the terminal
+2. Install the dependencies by running the following command: `npm install`
+3. After installation is complete, run `npm run dev` in the terminal
+4. The server should now be running at http://localhost:5173

--- a/UX/backend/src/services/pages.service.ts
+++ b/UX/backend/src/services/pages.service.ts
@@ -36,7 +36,7 @@ export class PageService {
       };
     } catch (error) {
       console.error('Error when fetching pages: ', error);
-      throw new Error('Error when fetching pages: ', error);
+      throw new Error(`Error when fetching pages`);
     }
   }
 
@@ -51,7 +51,7 @@ export class PageService {
 
       if (error) {
         console.error('Error when fetching page: ', error);
-        throw new Error('Error when fetching page: ', error);
+        throw new Error(`Error when fetching ${page} page`);
       }
 
       //Convert the blob to JSON
@@ -63,7 +63,7 @@ export class PageService {
       };
     } catch (error) {
       console.error('Error when fetching page: ', error);
-      throw new Error('Error when fetching page: ', error);
+      throw new Error(`Error when fetching ${page} page`);
     }
   }
 
@@ -76,7 +76,7 @@ export class PageService {
 
       if (error) {
         console.error('Error when fetching reviews: ', error);
-        throw new Error('Error when fetching reviews', error);
+        throw new Error(`Error when fetching reviews`);
       }
 
       const formattedReview = data?.map((review) => ({
@@ -90,7 +90,7 @@ export class PageService {
       };
     } catch (error) {
       console.error('Error when fetching reviews: ', error);
-      throw new Error('Error when fetching reviews: ', error);
+      throw new Error(`Error when fetching reviews`);
     }
   }
 }

--- a/UX/frontend/src/components/Editor/AuthMFA.tsx
+++ b/UX/frontend/src/components/Editor/AuthMFA.tsx
@@ -48,7 +48,7 @@ function AuthMFA({
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        maxWidth: 500,
+        maxWidth: 400,
         m: '5rem auto'
       }}>
       <Typography

--- a/UX/frontend/src/components/Editor/AuthMFA.tsx
+++ b/UX/frontend/src/components/Editor/AuthMFA.tsx
@@ -1,4 +1,5 @@
 import { supabase } from '@/config/supabase';
+import { useAuth } from '@/hooks/useAuth';
 import { Box, Button, TextField, Typography } from '@mui/material';
 import { useState } from 'react';
 
@@ -9,6 +10,7 @@ function AuthMFA({
 }) {
   const [verifyCode, setVerifyCode] = useState('');
   const [error, setError] = useState('');
+  const { signOut } = useAuth()
 
   const handleSubmit = () => {
     setError('');
@@ -40,6 +42,7 @@ function AuthMFA({
       onSuccess();
     })();
   };
+
   return (
     <Box
       sx={{
@@ -61,13 +64,22 @@ function AuthMFA({
         value={verifyCode}
         onChange={(e) => setVerifyCode(e.target.value.trim())}
       />
-      <Button
-        sx={{ my: 2 }}
-        variant='outlined'
-        onClick={handleSubmit}
-      >
-        Submit
-      </Button>
+      <Box>
+        <Button
+          sx={{ my: 2, mr: 1 }}
+          variant='outlined'
+          onClick={handleSubmit}
+        >
+          Submit
+        </Button>
+        <Button
+          sx={{ my: 2 }}
+          variant='outlined'
+          onClick={signOut}
+        >
+          Cancel
+        </Button>
+      </Box>
     </Box>
   );
 }

--- a/UX/frontend/src/components/Editor/AuthMFA.tsx
+++ b/UX/frontend/src/components/Editor/AuthMFA.tsx
@@ -67,7 +67,7 @@ function AuthMFA({
       <Box>
         <Button
           sx={{ my: 2, mr: 1 }}
-          variant='outlined'
+          variant='text_contained'
           onClick={handleSubmit}
         >
           Submit

--- a/UX/frontend/src/components/Editor/AuthMFA.tsx
+++ b/UX/frontend/src/components/Editor/AuthMFA.tsx
@@ -1,0 +1,75 @@
+import { supabase } from '@/config/supabase';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useState } from 'react';
+
+function AuthMFA({
+  onSuccess,
+}: {
+  onSuccess: () => void;
+}) {
+  const [verifyCode, setVerifyCode] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = () => {
+    setError('');
+    (async () => {
+      const factors = await supabase.auth.mfa.listFactors();
+      if (factors.error) {
+        throw factors.error;
+      }
+      const totpFactor = factors.data.all[0];
+      if (!totpFactor) {
+        throw new Error('No TOTP factors found!');
+      }
+      const factorId = totpFactor.id;
+      const challenge = await supabase.auth.mfa.challenge({ factorId });
+      if (challenge.error) {
+        setError(challenge.error.message);
+        throw challenge.error;
+      }
+      const challengeId = challenge.data.id;
+      const verify = await supabase.auth.mfa.verify({
+        factorId,
+        challengeId,
+        code: verifyCode,
+      });
+      if (verify.error) {
+        setError(verify.error.message);
+        throw verify.error;
+      }
+      onSuccess();
+    })();
+  };
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        maxWidth: 500,
+        m: '5rem auto'
+      }}>
+      <Typography
+        sx={{ mb: 1 }}
+        variant='body3'
+      >
+        Please enter the code from your authenticator app
+      </Typography>
+      {error && <Box className='error'>{error}</Box>}
+      <TextField
+        variant='outlined'
+        type='text'
+        value={verifyCode}
+        onChange={(e) => setVerifyCode(e.target.value.trim())}
+      />
+      <Button
+        sx={{ my: 2 }}
+        variant='outlined'
+        onClick={handleSubmit}
+      >
+        Submit
+      </Button>
+    </Box>
+  );
+}
+
+export default AuthMFA;

--- a/UX/frontend/src/components/Editor/EnrollMFA.tsx
+++ b/UX/frontend/src/components/Editor/EnrollMFA.tsx
@@ -52,16 +52,19 @@ export function EnrollMFA({
     if (wantsToEnroll) {
       (async () => {
         try {
+          setError('')
+          setVerifyError('')
           const { data: listData, error: listError } = await supabase.auth.mfa.listFactors();
-          if (listError) throw new Error('Something went wrong when fetching devices');
+          if (listError) throw listError;
 
           // Only allow one device per user
-          if (listData.totp.length > 0) throw new Error('We only allow one device per user. If you wish to change the device, remove it in the settings beforehand')
+          if (listData.totp.length > 0) throw new Error('We only allow one device per user. If you wish to change the device, log in and remove the active device the settings')
 
           // If the user has started the process, it will be stored until it activates
           if (listData.all[0] && listData.totp.length < 1) {
             setFactorId(listData.all[0].id)
-            const STORED_QR = JSON.parse(sessionStorage.getItem('QR')!)
+            const STORED_QR = JSON.parse(sessionStorage.getItem('QR') ?? '')
+            if (!STORED_QR) throw new Error(`No stored QR was found`)
             return setQR(STORED_QR)
           }
 

--- a/UX/frontend/src/components/Editor/EnrollMFA.tsx
+++ b/UX/frontend/src/components/Editor/EnrollMFA.tsx
@@ -1,0 +1,129 @@
+import { supabase } from '@/config/supabase';
+import { useAuth } from '@/hooks/useAuth';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+
+export function EnrollMFA({
+  onEnrolled,
+}: {
+  onEnrolled: () => void;
+}) {
+  const [factorId, setFactorId] = useState('');
+  const [qr, setQR] = useState('');
+  const [verifyCode, setVerifyCode] = useState('');
+  const [error, setError] = useState('');
+  const [wantsToEnroll, setWantsToEnroll] = useState(false)
+  const { signOut } = useAuth()
+
+  const onEnableClicked = async () => {
+    setError('');
+    try {
+      const challenge = await supabase.auth.mfa.challenge({ factorId });
+      if (challenge.error) {
+        setError(challenge.error.message);
+        return;
+      }
+
+      const { id: challengeId } = challenge.data;
+
+      const verify = await supabase.auth.mfa.verify({
+        factorId,
+        challengeId,
+        code: verifyCode,
+      });
+
+      if (verify.error) {
+        await supabase.auth.refreshSession();
+        setError(verify.error.message);
+        return;
+      }
+
+      onEnrolled();
+    } catch (err: any) {
+      setError(err.message ?? 'Unexpected error');
+    }
+  };
+
+  useEffect(() => {
+    if (wantsToEnroll) {
+      (async () => {
+        try {
+          // First check for any existing unverified factors
+          const { data: listData, error: listError } = await supabase.auth.mfa.listFactors();
+          if (listError) throw listError;
+
+          const unverifiedFactor = listData?.all.find(f => f.status === 'unverified' && f.factor_type === 'totp');
+
+          if (unverifiedFactor) {
+            setFactorId(unverifiedFactor.id);
+            return;
+          }
+
+          // If none exist, attempt to enroll a new one
+          const { data: enrollData, error: enrollError } = await supabase.auth.mfa.enroll({
+            factorType: 'totp',
+            issuer: 'TerraX9',
+          });
+
+
+
+
+          if (enrollError) throw enrollError;
+
+          setFactorId(enrollData.id);
+          setQR(enrollData.totp.qr_code);
+        } catch (err: any) {
+          setError(err.message ?? 'Failed to enroll MFA');
+        }
+      })();
+    }
+  }, [wantsToEnroll]);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: 'fit-content',
+        margin: '5rem auto',
+        p: 4,
+        gap: 2,
+        maxWidth: 500
+      }}
+    >
+      {
+        wantsToEnroll ?
+          (
+            <>
+              {error && <Typography variant='body1' color="error">Sorry, there was an issue enabling MFA. Try again later or contact IT support</Typography>}
+              {qr && <img src={qr} alt="QR code unavailable" />}
+
+              <TextField
+                variant="outlined"
+                value={verifyCode}
+                onChange={(e) => setVerifyCode(e.target.value.trim())}
+              />
+
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Button type="button" variant="outlined" onClick={onEnableClicked}>
+                  Enable
+                </Button>
+                <Button type="button" variant="outlined" onClick={() => setWantsToEnroll(false)}>
+                  Cancel
+                </Button>
+              </Box>
+
+            </>
+          )
+          :
+          <>
+            <Typography>We require all administrators to enable Multi-Factor Authentication</Typography>
+            <Box>
+              <Button onClick={() => setWantsToEnroll(true)}>Enable</Button>
+              <Button onClick={signOut}>Cancel</Button>
+            </Box>
+          </>
+      }
+    </Box>
+  );
+}

--- a/UX/frontend/src/components/Editor/Menu.tsx
+++ b/UX/frontend/src/components/Editor/Menu.tsx
@@ -1,0 +1,66 @@
+import { useContent } from '@/hooks/useContent';
+import { Box, Tab, Tabs } from '@mui/material';
+import { useEffect, useState } from 'react';
+import Settings from './Settings';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function CustomTabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`editor-tabpanel-${index}`}
+      aria-labelledby={`editor-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  );
+}
+
+function Menu() {
+  const { pages } = useContent()
+  const [value, setValue] = useState(0);
+
+  const handleChange = (_: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  useEffect(() => {
+    if (!pages) return
+  }, [pages])
+
+  if (!pages) return
+
+  return (
+    <>
+      <Tabs onChange={handleChange} value={value}>
+        <Tab label='Hero' />
+        <Tab label='Product' />
+        <Tab label='Support' />
+        <Tab label='Settings' />
+      </Tabs>
+      <CustomTabPanel value={value} index={0}>
+        Hero Page
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={1}>
+        Product page
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={2}>
+        Support page
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={3}>
+        <Settings />
+      </CustomTabPanel>
+    </>
+  )
+}
+
+export default Menu;

--- a/UX/frontend/src/components/Editor/Settings.tsx
+++ b/UX/frontend/src/components/Editor/Settings.tsx
@@ -1,0 +1,162 @@
+import { supabase } from '@/config/supabase';
+import { useAuth } from '@/hooks/useAuth';
+import {
+  Box,
+  Button,
+  List,
+  ListItem,
+  Modal,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import AuthMFA from './AuthMFA';
+import { Factor } from '@supabase/supabase-js';
+
+function Settings() {
+  const { signOut, session, MFAStatus } = useAuth();
+  const [qr, setQr] = useState('');
+  const [factors, setFactors] = useState<Factor[]>(session?.user.factors ?? []);
+  const [hasScanned, setHasScanned] = useState(false);
+
+  // Modal functionality
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+    enroll();
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    if (!MFAStatus) return setHasScanned(false)
+  };
+
+  // Enrollment flow
+  async function enroll() {
+    const newDeviceName = `Device ${factors.length + 1}`;
+    const { data, error } = await supabase.auth.mfa.enroll({
+      factorType: 'totp',
+      issuer: 'TerraX9',
+      friendlyName: newDeviceName,
+    });
+
+    if (error && error.status === 422) {
+      const deviceToRemove = factors.find(
+        (factor) => factor.friendly_name === newDeviceName
+      );
+      if (!deviceToRemove) throw new Error('Cannot find device to remove')
+      unEnroll(deviceToRemove.id);
+      return enroll();
+    } else if (error) throw new Error(`Auth error: ${error}`);
+
+    if (!data) return;
+    setQr(data.totp.qr_code);
+  }
+
+  // Listing all factors (testing)
+  async function listFactors() {
+    const { data, error } = await supabase.auth.mfa.listFactors();
+    if (error) throw new Error(`Auth error: ${error}`);
+    return data;
+  }
+
+  // Remove MFA Factor
+  async function unEnroll(id: string) {
+    const { error } = await supabase.auth.mfa.unenroll({ factorId: id });
+    if (error) console.error(error);
+    await supabase.auth.refreshSession()
+    listFactors().then((data) => setFactors(data.totp));
+  }
+
+  return (
+    <Stack
+      component='div'
+      sx={{
+        minHeight: 500,
+        maxWidth: 650,
+        margin: '0 auto',
+        p: 4,
+        display: 'flex',
+        gap: 4,
+      }}
+    >
+      <Box component='section'>
+        <Typography
+          variant='h2'
+          sx={{ fontSize: '18px', mb: 2 }}
+        >
+          Options
+        </Typography>
+        <Button onClick={signOut}>Log out</Button>
+      </Box>
+
+      <Box component='section'>
+        <Typography
+          variant='h2'
+          sx={{ fontSize: '18px', mb: 2 }}
+        >
+          Multi-Factor Authentication
+        </Typography>
+        <Box sx={{ width: 'fit-content' }}></Box>
+        {factors.length > 0 ? (
+          <>
+            <List>
+              {factors.map((factor, index) => (
+                <ListItem
+                  key={factor.id}
+                  sx={{ justifyContent: 'space-between', p: 0 }}
+                >
+                  <Typography>
+                    {factor.friendly_name ?? `Device ${index + 1}`}
+                  </Typography>
+                  <Button onClick={() => unEnroll(factor.id)}>Remove</Button>
+                </ListItem>
+              ))}
+            </List>
+            <Button onClick={handleOpen}>Add Another Device</Button>
+          </>
+        ) : (
+          <Button onClick={handleOpen}>Enable MFA</Button>
+        )}
+      </Box>
+
+      {/* Modal: Enabling MFA */}
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby='modal-modal-title'
+        aria-describedby='modal-modal-description'
+      >
+        <Box
+          sx={{
+            backgroundColor: 'primary.background',
+            width: 'fit-content',
+            p: 4,
+            m: '5rem auto',
+          }}
+        >
+          {qr && !hasScanned && (
+            <>
+              <img
+                src={qr}
+                alt=''
+                style={{ margin: '0 auto' }}
+              />
+              <Button onClick={() => setHasScanned(true)}>
+                I have scanned the QR Code
+              </Button>
+            </>
+          )}
+          {hasScanned && (
+            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+              <AuthMFA onSuccess={() => window.location.reload()} />
+            </Box>
+          )}
+        </Box>
+      </Modal>
+    </Stack>
+  );
+}
+
+export default Settings;

--- a/UX/frontend/src/components/Editor/Settings.tsx
+++ b/UX/frontend/src/components/Editor/Settings.tsx
@@ -5,68 +5,34 @@ import {
   Button,
   List,
   ListItem,
-  Modal,
   Stack,
   Typography,
 } from '@mui/material';
-import { useState } from 'react';
-import AuthMFA from './AuthMFA';
+import { useEffect, useState } from 'react';
 import { Factor } from '@supabase/supabase-js';
 
 function Settings() {
-  const { signOut, session, MFAStatus } = useAuth();
-  const [qr, setQr] = useState('');
-  const [factors, setFactors] = useState<Factor[]>(session?.user.factors ?? []);
-  const [hasScanned, setHasScanned] = useState(false);
+  const { signOut } = useAuth();
+  const [factors, setFactors] = useState<Factor[]>([]);
 
-  // Modal functionality
-  const [open, setOpen] = useState(false);
-
-  const handleOpen = () => {
-    setOpen(true);
-    enroll();
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-    if (!MFAStatus) return setHasScanned(false)
-  };
-
-  // Enrollment flow
-  async function enroll() {
-    const newDeviceName = `Device ${factors.length + 1}`;
-    const { data, error } = await supabase.auth.mfa.enroll({
-      factorType: 'totp',
-      issuer: 'TerraX9',
-      friendlyName: newDeviceName,
-    });
-
-    if (error && error.status === 422) {
-      const deviceToRemove = factors.find(
-        (factor) => factor.friendly_name === newDeviceName
-      );
-      if (!deviceToRemove) throw new Error('Cannot find device to remove')
-      unEnroll(deviceToRemove.id);
-      return enroll();
-    } else if (error) throw new Error(`Auth error: ${error}`);
-
-    if (!data) return;
-    setQr(data.totp.qr_code);
-  }
-
-  // Listing all factors (testing)
+  // List all factors
   async function listFactors() {
     const { data, error } = await supabase.auth.mfa.listFactors();
     if (error) throw new Error(`Auth error: ${error}`);
     return data;
   }
 
+  // List factors upon mount
+  useEffect(() => {
+    if (factors.length < 1) listFactors().then(data => setFactors(data.totp))
+  }, [])
+
   // Remove MFA Factor
   async function unEnroll(id: string) {
     const { error } = await supabase.auth.mfa.unenroll({ factorId: id });
     if (error) console.error(error);
     await supabase.auth.refreshSession()
-    listFactors().then((data) => setFactors(data.totp));
+    signOut().then(() => window.location.reload())
   }
 
   return (
@@ -99,7 +65,7 @@ function Settings() {
           Multi-Factor Authentication
         </Typography>
         <Box sx={{ width: 'fit-content' }}></Box>
-        {factors.length > 0 ? (
+        {factors.length > 0 && (
           <>
             <List>
               {factors.map((factor, index) => (
@@ -114,47 +80,9 @@ function Settings() {
                 </ListItem>
               ))}
             </List>
-            <Button onClick={handleOpen}>Add Another Device</Button>
           </>
-        ) : (
-          <Button onClick={handleOpen}>Enable MFA</Button>
         )}
       </Box>
-
-      {/* Modal: Enabling MFA */}
-      <Modal
-        open={open}
-        onClose={handleClose}
-        aria-labelledby='modal-modal-title'
-        aria-describedby='modal-modal-description'
-      >
-        <Box
-          sx={{
-            backgroundColor: 'primary.background',
-            width: 'fit-content',
-            p: 4,
-            m: '5rem auto',
-          }}
-        >
-          {qr && !hasScanned && (
-            <>
-              <img
-                src={qr}
-                alt=''
-                style={{ margin: '0 auto' }}
-              />
-              <Button onClick={() => setHasScanned(true)}>
-                I have scanned the QR Code
-              </Button>
-            </>
-          )}
-          {hasScanned && (
-            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-              <AuthMFA onSuccess={() => window.location.reload()} />
-            </Box>
-          )}
-        </Box>
-      </Modal>
     </Stack>
   );
 }

--- a/UX/frontend/src/components/Spinner.tsx
+++ b/UX/frontend/src/components/Spinner.tsx
@@ -1,0 +1,19 @@
+import { Box, CircularProgress } from '@mui/material';
+
+function Spinner() {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        width: '100%',
+        minHeight: '500px',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <CircularProgress />
+    </Box>
+  );
+}
+
+export default Spinner;

--- a/UX/frontend/src/context/AuthContext.tsx
+++ b/UX/frontend/src/context/AuthContext.tsx
@@ -6,6 +6,7 @@ export interface AuthContextType {
   user: User | null;
   loading: boolean;
   signOut: () => Promise<void>;
+  MFAStatus: 'Verified' | 'Unverified' | null | undefined
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/UX/frontend/src/context/AuthContext.tsx
+++ b/UX/frontend/src/context/AuthContext.tsx
@@ -6,7 +6,6 @@ export interface AuthContextType {
   user: User | null;
   loading: boolean;
   signOut: () => Promise<void>;
-  MFAStatus: 'Verified' | 'Unverified' | null | undefined
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/UX/frontend/src/context/AuthProvider.tsx
+++ b/UX/frontend/src/context/AuthProvider.tsx
@@ -5,7 +5,6 @@ import { supabase } from '../config/supabase';
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<AuthContextType["session"]>(null);
   const [user, setUser] = useState<AuthContextType["user"]>(null);
-  const [MFAStatus, setMFAStatus] = useState<AuthContextType["MFAStatus"]>(undefined);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -15,22 +14,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const { data: { session } } = await supabase.auth.getSession();
         setSession(session);
         setUser(session?.user ?? null);
-
-        const { data: assuranceData, error: assuranceError } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-        const { data: factorData, error: factorError } = await supabase.auth.mfa.listFactors();
-
-        if (assuranceError || !assuranceData || factorError || factorData.all.length < 1) {
-          setMFAStatus(null);
-        } else if (assuranceData.currentLevel === 'aal1' && assuranceData.nextLevel === 'aal2') {
-          setMFAStatus('Unverified');
-        } else if (assuranceData.currentLevel === 'aal2') {
-          setMFAStatus('Verified');
-        } else {
-          setMFAStatus(null);
-        }
       } catch (error) {
         console.error('Error loading auth:', error);
-        setMFAStatus(null);
       } finally {
         setLoading(false);
       }
@@ -57,7 +42,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     user,
     loading,
     signOut,
-    MFAStatus
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/UX/frontend/src/context/AuthProvider.tsx
+++ b/UX/frontend/src/context/AuthProvider.tsx
@@ -5,6 +5,7 @@ import { supabase } from '../config/supabase';
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<AuthContextType["session"]>(null);
   const [user, setUser] = useState<AuthContextType["user"]>(null);
+  const [MFAStatus, setMFAStatus] = useState<AuthContextType["MFAStatus"]>(undefined);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -22,6 +23,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setLoading(false);
     });
 
+    (async () => {
+      try {
+        setLoading(true)
+        const { data, error } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+        if (error || !data || !session?.user.factors) return setMFAStatus(null)
+        if (data.currentLevel === 'aal1' && data.nextLevel === 'aal2') return setMFAStatus('Unverified')
+        if (data.currentLevel === 'aal2' && data.nextLevel === 'aal2') return setMFAStatus('Verified')
+        else if (data.currentLevel === 'aal1' && data.nextLevel === 'aal1') return setMFAStatus(null)
+      } catch (error) {
+        setMFAStatus(null)
+      } finally {
+        setLoading(false)
+      }
+    })()
+
+
     return () => subscription.unsubscribe();
   }, []);
 
@@ -34,6 +51,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     user,
     loading,
     signOut,
+    MFAStatus
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/UX/frontend/src/pages/Editor/Editor.tsx
+++ b/UX/frontend/src/pages/Editor/Editor.tsx
@@ -3,6 +3,8 @@ import { useAuth } from '../../hooks/useAuth';
 import Menu from '@/components/Editor/Menu';
 import AuthMFA from '@/components/Editor/AuthMFA';
 import Spinner from '@/components/Spinner';
+import { EnrollMFA } from '@/components/Editor/EnrollMFA';
+
 function Editor() {
   const { user } = useAuth()
   const { MFAStatus, loading } = useAuth()
@@ -14,7 +16,9 @@ function Editor() {
   if (loading) return <Spinner />
 
   // If user has enabled MFA + is currently unverified, will be asked to verify
-  if (MFAStatus === 'Unverified') {
+  if (MFAStatus === null) {
+    return <EnrollMFA onEnrolled={() => window.location.reload()} />
+  } else if (MFAStatus === 'Unverified') {
     return <AuthMFA onSuccess={() => window.location.reload()} />
   }
   return <Menu />

--- a/UX/frontend/src/pages/Editor/Editor.tsx
+++ b/UX/frontend/src/pages/Editor/Editor.tsx
@@ -1,21 +1,23 @@
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
-
-
+import Menu from '@/components/Editor/Menu';
+import AuthMFA from '@/components/Editor/AuthMFA';
+import Spinner from '@/components/Spinner';
 function Editor() {
-  const { user, signOut } = useAuth()
+  const { user } = useAuth()
+  const { MFAStatus, loading } = useAuth()
 
   if (!user) {
     return <Navigate to="/login" />;
   }
 
-  return (
-    <>
-      <button onClick={signOut}>Logout</button>
-      <p>Currently logged in as admin: {user.email}</p>
-    </>
-  )
+  if (loading) return <Spinner />
 
+  // If user has enabled MFA + is currently unverified, will be asked to verify
+  if (MFAStatus === 'Unverified') {
+    return <AuthMFA onSuccess={() => window.location.reload()} />
+  }
+  return <Menu />
 }
 
 export default Editor;

--- a/UX/frontend/src/pages/Editor/Editor.tsx
+++ b/UX/frontend/src/pages/Editor/Editor.tsx
@@ -16,7 +16,7 @@ function Editor() {
   if (loading) return <Spinner />
 
   // If user has enabled MFA + is currently unverified, will be asked to verify
-  if (MFAStatus === null) {
+  if (!MFAStatus) {
     return <EnrollMFA onEnrolled={() => window.location.reload()} />
   } else if (MFAStatus === 'Unverified') {
     return <AuthMFA onSuccess={() => window.location.reload()} />

--- a/UX/frontend/src/pages/Editor/Editor.tsx
+++ b/UX/frontend/src/pages/Editor/Editor.tsx
@@ -4,10 +4,39 @@ import Menu from '@/components/Editor/Menu';
 import AuthMFA from '@/components/Editor/AuthMFA';
 import Spinner from '@/components/Spinner';
 import { EnrollMFA } from '@/components/Editor/EnrollMFA';
+import { useEffect, useState } from 'react';
+import { supabase } from '@/config/supabase';
+
+type MFAStatus = 'Verified' | 'Unverified' | null
 
 function Editor() {
   const { user } = useAuth()
-  const { MFAStatus, loading } = useAuth()
+  const [MFAStatus, setMFAStatus] = useState<MFAStatus>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function getMFAStatus() {
+      try {
+        const { data: assuranceData, error: assuranceError } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        if (assuranceError || !assuranceData) throw assuranceError
+
+        if (assuranceData.currentLevel === 'aal1' && assuranceData.nextLevel === 'aal2') {
+          return setMFAStatus('Unverified');
+        } else if (assuranceData.currentLevel === 'aal2') {
+          return setMFAStatus('Verified');
+        }
+        setMFAStatus(null)
+
+      } catch (error) {
+        console.error(error)
+        setMFAStatus(null)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    getMFAStatus()
+  }, [])
 
   if (!user) {
     return <Navigate to="/login" />;

--- a/UX/frontend/src/pages/Editor/Root.tsx
+++ b/UX/frontend/src/pages/Editor/Root.tsx
@@ -1,0 +1,14 @@
+import { Box } from '@mui/material';
+import { Outlet } from 'react-router-dom';
+
+// This is the root of editor
+function Root() {
+
+  return (
+    <Box sx={{ pt: '94.89px' }}>
+      <Outlet />
+    </Box>
+  )
+}
+
+export default Root;

--- a/UX/frontend/src/pages/Hero.tsx
+++ b/UX/frontend/src/pages/Hero.tsx
@@ -20,12 +20,14 @@ function Hero() {
         // Banner Section
         component='section'
         id='hero_banner'
-        sx={{ height: 1000, position: 'relative' }}>
+        sx={{ height: 1000 }}>
 
         {/* Video */}
-        <video autoPlay loop muted style={{ height: 1000 }} src={`${import.meta.env.VITE_SUPABASE_URL}/storage/v1/object/public/images//hero_banner.mp4`} />
-        <Box aria-hidden='true'
-          sx={{ height: 150, width: '100%', background: 'linear-gradient(0deg, #05030C, rgba(0,0,0,0))', position: 'absolute', bottom: 0 }} />
+        <Box sx={{ position: 'relative' }}>
+          <video autoPlay loop muted style={{ width: '100%' }} src={`${import.meta.env.VITE_SUPABASE_URL}/storage/v1/object/public/images//hero_banner.mp4`} />
+          <Box aria-hidden='true'
+            sx={{ height: 150, width: '100%', background: 'linear-gradient(0deg, #05030C, rgba(0,0,0,0))', position: 'absolute', bottom: 0 }} />
+        </Box>
 
         <Box
           sx={{

--- a/UX/frontend/src/pages/Hero.tsx
+++ b/UX/frontend/src/pages/Hero.tsx
@@ -17,19 +17,15 @@ function Hero() {
       }}
     >
       <Box
-        // Hero Section
+        // Banner Section
         component='section'
         id='hero_banner'
-        sx={{
-          //Image is currently static.
-          backgroundImage:
-            'url("https://qxlvyblcyywkxiqtbcrb.supabase.co/storage/v1/object/public/images//video_still.png")',
-          backgroundSize: 'cover',
-          backgroundPosition: 'bottom',
-          height: 1000,
-          position: 'relative'
-        }}
-      >
+        sx={{ height: 1000, position: 'relative' }}>
+
+        {/* Video */}
+        <video autoPlay loop muted style={{ height: 1000 }} src={`${import.meta.env.VITE_SUPABASE_URL}/storage/v1/object/public/images//hero_banner.mp4`} />
+        <Box aria-hidden='true'
+          sx={{ height: 150, width: '100%', background: 'linear-gradient(0deg, #05030C, rgba(0,0,0,0))', position: 'absolute', bottom: 0 }} />
 
         <Box
           sx={{

--- a/UX/frontend/src/router/router.tsx
+++ b/UX/frontend/src/router/router.tsx
@@ -7,7 +7,7 @@ import Login from '../pages/Editor/Login';
 import Editor from '../pages/Editor/Editor';
 import { AuthRedirect } from '../pages/Editor/AuthRedirect';
 import Root from '../components/Root';
-
+import EditorRoot from '../pages/Editor/Root'
 
 export const router = createBrowserRouter([
   {
@@ -37,7 +37,11 @@ export const router = createBrowserRouter([
     },
     {
       path: '/editor',
-      element: <Editor />
+      element: <EditorRoot />,
+      children: [{
+        path: '/editor',
+        element: <Editor />,
+      }]
     }]
   },
 

--- a/UX/frontend/src/theme/theme.ts
+++ b/UX/frontend/src/theme/theme.ts
@@ -24,7 +24,7 @@ export const theme = createTheme({
       fontSize: 'clamp(40px, 3vw, 48px);',
       fontWeight: 700,
       fontFamily: 'Lexend Exa, sans-serif',
-      textWrap: 'balance'
+      textWrap: 'balance',
     },
     h2: {
       fontSize: '36px',
@@ -55,7 +55,7 @@ export const theme = createTheme({
       fontSize: '20px',
       fontWeight: 400,
       fontFamily: 'Instrument Sans, sans-serif',
-      lineHeight: '30px'
+      lineHeight: '30px',
     },
     body2: {
       fontSize: '18px',
@@ -78,6 +78,11 @@ export const theme = createTheme({
       letterSpacing: '2.88px',
       fontWeight: 700,
     },
+    subheading2: {
+      fontSize: 20,
+      fontWeight: 500,
+      fontFamily: 'Lexend Exa, sans-serif'
+    }
   },
   shadows: [
     'none',
@@ -122,10 +127,17 @@ export const theme = createTheme({
           boxShadow: 'none',
           filter: 'drop-shadow(0px 11px 10px black)',
           '& a :hover': { textShadow: '0px 9px 8px #5526FF' },
-          '& a': { color: 'text.primary', textDecoration: 'none', transition: 'text-shadow 60ms' },
-          '& a:is(#logo) img': { transition: 'filter 60ms',  transitionDelay: 0 },
+          '& a': {
+            color: 'text.primary',
+            textDecoration: 'none',
+            transition: 'text-shadow 60ms',
+          },
+          '& a:is(#logo) img': {
+            transition: 'filter 60ms',
+            transitionDelay: 0,
+          },
           '& a:is(#logo):hover img': {
-            filter: 'drop-shadow(0px 10px 10px #5526FF)'
+            filter: 'drop-shadow(0px 10px 10px #5526FF)',
           }, //
           '& a:not(#logo)::after': {
             content: '""',
@@ -142,6 +154,8 @@ export const theme = createTheme({
     MuiButton: {
       styleOverrides: {
         root: {
+          width: 'fit-content',
+          maxWidth: '100%',
           variants: [
             {
               props: { variant: 'contained' },
@@ -162,18 +176,43 @@ export const theme = createTheme({
                 '&:hover': {
                   boxShadow: '8px 8px 14px 0px rgba(255, 255, 255, 0.24)',
                   border: '1px solid rgba(255, 255, 255, 0.50)',
-                  backgroundColor: '#5526FF'
-                }
-              }
-            }
-          ]
-        }
-      }
+                  backgroundColor: '#5526FF',
+                },
+              },
+            },
+          ],
+        },
+      },
     },
     MuiButtonBase: {
       defaultProps: {
-        disableRipple: true
-      }
-    }
+        disableRipple: true,
+      },
+    },
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          maxWidth: '100%',
+          color: '#FFF',
+          flex: 1,
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundColor: '#05030C',
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          backgroundColor: '#181724',
+          border: '1px solid rgba(188, 197, 255, 1)',
+          '&::placeholder': { color: 'rgb(93 92 101)' },
+        },
+      },
+    },
   },
 });

--- a/UX/frontend/src/theme/theme.ts
+++ b/UX/frontend/src/theme/theme.ts
@@ -180,6 +180,14 @@ export const theme = createTheme({
                 },
               },
             },
+            {
+              props: { variant: 'text_contained'},
+              style: {
+                backgroundColor: '#5526FF',
+                color: '#FFF',
+                '&:hover': {backgroundColor: '#3C16C3'}
+              }
+            }
           ],
         },
       },

--- a/UX/frontend/src/theme/types.ts
+++ b/UX/frontend/src/theme/types.ts
@@ -24,3 +24,11 @@ declare module '@mui/material/Typography' {
     subheading2: true;
   }
 }
+
+// Custom  Components
+
+declare module '@mui/material/Button' {
+  interface ButtonPropsVariantOverrides {
+    text_contained: true;
+  }
+}

--- a/UX/frontend/src/theme/types.ts
+++ b/UX/frontend/src/theme/types.ts
@@ -6,12 +6,14 @@ declare module '@mui/material/styles' {
     headerlink: React.CSSProperties;
     footerlabel: React.CSSProperties;
     body3: React.CSSProperties;
+    subheading2: React.CSSProperties;
   }
 
   interface TypographyVariantsOptions {
     headerlink?: React.CSSProperties;
     footerlabel?: React.CSSProperties;
     body3?: React.CSSProperties;
+    subheading2?: React.CSSProperties;
   }
 }
 declare module '@mui/material/Typography' {
@@ -19,6 +21,6 @@ declare module '@mui/material/Typography' {
     headerlink: true;
     footerlabel: true;
     body3: true;
-
+    subheading2: true;
   }
 }


### PR DESCRIPTION
### **Summary**
- Add MFA functionality to the editor

### **Testing Prerequisites**
- Login info (Contact me for the details)
- A mobile authenticator app (Micorsoft Authenticator / Authy / something similar)

### **How to test it**
1. Start up the servers (Instructions in UX/README.md)
1. Navigate to `http://localhost:5173/editor` (It's a hidden feature of the website, so no link/button anywhere)
2. Enter login details
3. You will be asked to add a MFA device
4. Scan QR code, enter the code from your device, then click 'Submit'
5. You should be allowed to the editor
6. In the 'settings' tab, you can remove the device. This will log you out and requires you to add a new device, starting over.

Known flaws: 
Because you need the highest assurance level to remove any device, it becomes very problematic if you try to cancel the already-begun process of authenticating. Hopefully I can find a workaround, but until then, I enforce user intent by allowing the user to press "Enable" after logging in.