### PR TITLE
Speed bug Fix

### DIFF
--- a/Embedded/Arduino/Motor_controller/src/Calculations/Drive.cpp
+++ b/Embedded/Arduino/Motor_controller/src/Calculations/Drive.cpp
@@ -76,9 +76,9 @@ DriveState Drive::GetState() {
    Om state är STOPPED, ska en annan funktion anropas som stoppar motorerna
 */
 void Drive::ExecuteDriveLogic() {
-    int currentSpeed = round(CalculateHypotenuse());
-    int leftSpeed = round(CalculateLeftSpeedFunc());
-    int rightSpeed = round(CalculateRightSpeedFunc());
+    int currentSpeed = round(CalculateHypotenuse()*255);
+    int leftSpeed = round(CalculateLeftSpeedFunc()*255);
+    int rightSpeed = round(CalculateRightSpeedFunc()*255);
     DriveState dir = GetState();
     printf("Left Speed: %d, Right Speed: %d\n", leftSpeed, rightSpeed);
     // Skriver ut states, beroende på x och y (for testing)

--- a/Embedded/Arduino/Motor_controller/src/Calculations/Drive.cpp
+++ b/Embedded/Arduino/Motor_controller/src/Calculations/Drive.cpp
@@ -10,6 +10,9 @@
 
 using namespace std;
 
+// Konstant som används för att beräkna hastigheten till PWM
+const int PWM_SCALE = 255;
+
 
 // Hämtar globala instansen av MotorController
 extern MotorController motorController;
@@ -76,9 +79,9 @@ DriveState Drive::GetState() {
    Om state är STOPPED, ska en annan funktion anropas som stoppar motorerna
 */
 void Drive::ExecuteDriveLogic() {
-    int currentSpeed = round(CalculateHypotenuse()*255);
-    int leftSpeed = round(CalculateLeftSpeedFunc()*255);
-    int rightSpeed = round(CalculateRightSpeedFunc()*255);
+    int currentSpeed = round(CalculateHypotenuse()* PWM_SCALE);
+    int leftSpeed = round(CalculateLeftSpeedFunc()* PWM_SCALE);
+    int rightSpeed = round(CalculateRightSpeedFunc()* PWM_SCALE);
     DriveState dir = GetState();
     printf("Left Speed: %d, Right Speed: %d\n", leftSpeed, rightSpeed);
     // Skriver ut states, beroende på x och y (for testing)

--- a/Embedded/Arduino/Motor_controller/test/drive_test.cpp
+++ b/Embedded/Arduino/Motor_controller/test/drive_test.cpp
@@ -93,9 +93,9 @@ TEST(DriveTest, AlgorithmPrintsForward) {
 
     // Anpassat för heltals‐utskrift + mock‐rad
     std::string expected =
-        "Left Speed: 1, Right Speed: 1\n"
+        "Left Speed: 255, Right Speed: 255\n"
         "State: GO FWD\n"
-        "Mock DriveForward: 1, 1\n";
+        "Mock DriveForward: 255, 255\n";
 
     EXPECT_EQ(output, expected)
         << "Expected:\n" << expected << "\nbut got:\n" << output;
@@ -110,9 +110,9 @@ TEST(DriveTest, AlgorithmPrintsBackward) {
 
     // Anpassat för heltals‐utskrift + mock‐rad
     std::string expected =
-        "Left Speed: -1, Right Speed: -1\n"
+        "Left Speed: -255, Right Speed: -255\n"
         "State: GO BWD\n"
-        "Mock DriveBackward: -1, -1\n";
+        "Mock DriveBackward: -255, -255\n";
 
     EXPECT_EQ(output, expected)
         << "Expected:\n" << expected << "\nbut got:\n" << output;


### PR DESCRIPTION
I just made a little a modification in the Drive code to calculate the speed to correct PWM value. 
The PWM value needs to be an integer without any decimals. That is why i use the round() function