### PR TITLE
extra/update-github-standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Here are the decided general GitHub standards for the entire project.
 - Commit name should be short and clear.  
 - If more information is needed, put it in the commit description.
 
+### Branch naming convention
+ - A branch should be linked to a ticket. Then the name must be: `id/name-of-ticket`
+	- It should always be lower caps
+ - In the special case when a branch is not linked to a ticket it follow the convetion: `tag/name-of-assignment`
+	- Where tag should be something fitting like `bug`, `extra`, `update`, `fix` 
+
 ### Pull request
 - The PR name must match the branch naming standard: `id/name-of-ticket`
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Here are the decided general GitHub standards for the entire project.
 - If more information is needed, put it in the commit description.
 
 ### Pull request
+- The PR name must match the branch naming standard: `id/name-of-ticket`
 
-- Squash all commits before opening PR.  
 - Before creating a pull request, check these points:  
 	- Is my code tested enough so that all cases are checked?  
 	- Does my code affect any other part of the project? If so, make sure that code changes don't break any other part of the project.  
@@ -39,7 +39,7 @@ Here are the decided general GitHub standards for the entire project.
 A pull request should not be merged if any of these are not fulfilled:  
 	- No one from my team has reviewed my pull request.  
 	- If definition of done is not met.
-
+- The PR merging commit message must match the branch naming standard: `id/name-of-ticket`
 ___
 
 ## Code


### PR DESCRIPTION
A new suggestion for the GitHub standard:

- Removed that a PR must be sqashed before PR

+ Added rule: PR name must match branch naming convention
+ Added rule: PR merge commit message must match branch naming convention
+ Clairifed rule: Branch naming convention
+ Added rule: Branch naming convention where it is not linked to a ticket

Feel free to comment/add/edit anything you'd like! 
