### PR TITLE
fix/pararell-tasks

### DIFF
--- a/Embedded/RaspberryPI/commands/rover/handler.py
+++ b/Embedded/RaspberryPI/commands/rover/handler.py
@@ -5,8 +5,12 @@ from .rover_forwarder import *
 from config.settings import IS_RPI
 if IS_RPI:
     from commands.arm.arm_forwarder import forward_arm, forward_claw
+import asyncio
 
 async def process_command(websocket, data):
+    
+    # print(f"Will now process command: {data}")
+    # await asyncio.sleep(1)
     command = data.get("command")
     print(f"Received data: {data}")
     print(f"Command: {command}")

--- a/Embedded/RaspberryPI/communication/websocket_communication.py
+++ b/Embedded/RaspberryPI/communication/websocket_communication.py
@@ -65,7 +65,8 @@ if LOCAL_TEST == False:
                             # NOTE: This could also be put in a async queue so steering won't stop working during normal commands
                             if "steer" not in message:
                                 print(f"Forceful command: {message}")
-                                await process_command(websocket, data)
+                                #await process_command(websocket, data)
+                                asyncio.create_task(process_command(websocket, data))
                                 continue
                             
                             # If a steer command (drive)
@@ -115,4 +116,5 @@ else:
                 params = {command:{"x":x,"y":y}}
             else:
                 params = {"command": command}
-            await process_command(websocket, params)
+            #await process_command(websocket, params)
+            asyncio.create_task(process_command(websocket, params))


### PR DESCRIPTION
# Attempt to fix pararell tasks

**Before:** New incoming commands would be skipped if a command is being processed
**Now:** Ongoing processes of commands will be cancelled in turn of new incoming commands

This PR includes a commented-out hack to visually test that it is cancelling tasks as expected, this should probably be removed before accepting and mergin this pr.

Note: Perhaps some kind of clean up is needed after a task is stopped for the servos, I don't know :)

If it works one should improve the structure of this file as well :))

This fix assumes that the "motors" are all running blocking, otherwise I am note sure how it will work. E.g. if motor commands are "fired away" then cancelling the task won't do anything.